### PR TITLE
stop test cluster with INT rather than KILL

### DIFF
--- a/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
+++ b/elasticsearch-extensions/lib/elasticsearch/extensions/test/cluster.rb
@@ -152,10 +152,10 @@ module Elasticsearch
           pids  = nodes['nodes'].map { |id, info| info['process']['id'] }
 
           unless pids.empty?
-            print "Stopping Elasticsearch nodes... ".ansi(:faint)
+            print "\nStopping Elasticsearch nodes... ".ansi(:faint)
             pids.each_with_index do |pid, i|
               begin
-                print "stopped PID #{pid}. ".ansi(:green) if Process.kill 'KILL', pid
+                print "stopped PID #{pid}. ".ansi(:green) if Process.kill 'INT', pid
               rescue Exception => e
                 print "[#{e.class}] PID #{pid} not found. ".ansi(:red)
               end


### PR DESCRIPTION
since writing tests is supposed to ultimately alleviate programmer anxiety, rather than increase it, this PR sends the test cluster process a INT (please stop) signal rather than the harsher KILL (you are dead) signal. 
The KILL signal will cause the parent shell to exit with a scary "killed process N ...." with full command thereafter, causing lots of verbage in the terminal on what should be a normal, non-failure, process completion.

I'm not entirely sure of the history of using KILL (other than probably avoiding hung processes), but in my tests on various *nix flavors, INT works just fine. The docs claim it works on Windows too, though I have not tried.