### PR TITLE
Predicate methods should provide question mark versions

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -48,6 +48,8 @@ module Elasticsearch
             raise e
           end
       end
+
+      alias_method :exists?, :exists
     end
   end
 end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -50,6 +50,8 @@ module Elasticsearch
             raise e
           end
         end
+
+        alias_method :exists?, :exists
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -48,6 +48,8 @@ module Elasticsearch
             raise e
           end
         end
+
+        alias_method :exists_alias?, :exists_alias
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -47,6 +47,8 @@ module Elasticsearch
             raise e
           end
         end
+
+        alias_method :exists_type?, :exists_type
       end
     end
   end

--- a/elasticsearch-api/test/unit/exists?_document_test.rb
+++ b/elasticsearch-api/test/unit/exists?_document_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class ExistsTest < ::Test::Unit::TestCase
+
+      context "Exists document" do
+        subject { FakeClient.new }
+
+        should "require the :index argument" do
+          assert_raise ArgumentError do
+            subject.exists? :type => 'bar', :id => '1'
+          end
+        end
+
+        should "NOT require the :type argument" do
+          assert_nothing_raised do
+            subject.exists? :index => 'foo', :id => '1'
+          end
+        end
+
+        should "require the :id argument" do
+          assert_raise ArgumentError do
+            subject.exists? :index => 'foo', :type => 'bar'
+          end
+        end
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'HEAD', method
+            assert_equal 'foo/bar/1', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.exists? :index => 'foo', :type => 'bar', :id => '1'
+        end
+
+        should "pass the URL parameters" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo/bar/1', url
+            assert_equal 'abc123', params[:routing]
+            true
+          end.returns(FakeResponse.new)
+
+          subject.exists? :index => 'foo', :type => 'bar', :id => '1', :routing => 'abc123'
+        end
+
+        should "URL-escape the parts" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo/bar%2Fbam/1', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.exists? :index => 'foo', :type => 'bar/bam', :id => '1'
+        end
+
+        should "return true for successful response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 200, 'OK')
+          assert_equal true, subject.exists?(:index => 'foo', :type => 'bar', :id => '1')
+        end
+
+        should "return false for 404 response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 404, 'Not Found')
+          assert_equal false, subject.exists?(:index => 'foo', :type => 'bar', :id => '1')
+        end
+
+        should "return false on 'not found' exceptions" do
+          subject.expects(:perform_request).raises(StandardError.new '404 NotFound')
+          assert_equal false, subject.exists?(:index => 'foo', :type => 'bar', :id => '1')
+        end
+
+        should "re-raise generic exceptions" do
+          subject.expects(:perform_request).raises(StandardError)
+          assert_raise(StandardError) do
+            assert_equal false, subject.exists?(:index => 'foo', :type => 'bar', :id => '1')
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-api/test/unit/exists?_document_test.rb
+++ b/elasticsearch-api/test/unit/exists?_document_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Elasticsearch
   module Test
-    class ExistsTest < ::Test::Unit::TestCase
+    class ExistsQuestionTest < ::Test::Unit::TestCase
 
       context "Exists document" do
         subject { FakeClient.new }

--- a/elasticsearch-api/test/unit/indices/exists?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists?_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Elasticsearch
   module Test
-    class Indicesexists?Test < ::Test::Unit::TestCase
+    class IndicesexistsQuestionTest < ::Test::Unit::TestCase
 
       context "Indices: exists?" do
         subject { FakeClient.new }

--- a/elasticsearch-api/test/unit/indices/exists?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists?_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class Indicesexists?Test < ::Test::Unit::TestCase
+
+      context "Indices: exists?" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'HEAD', method
+            assert_equal 'foo', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists?(:index => 'foo')
+        end
+
+        should "perform the request against multiple indices" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo,bar', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists?(:index => ['foo', 'bar'])
+        end
+
+        should "URL-escape the parts" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo%5Ebar,bar%2Fbam', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists? :index => 'foo^bar,bar/bam'
+        end
+
+        should "return true for successful response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 200, 'OK')
+          assert_equal true, subject.indices.exists?(:index => 'foo')
+        end
+
+        should "return false for 404 response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 404, 'Not Found')
+          assert_equal false, subject.indices.exists?(:index => 'none')
+        end
+
+        should "return false on 'not found' exceptions" do
+          subject.expects(:perform_request).raises(StandardError.new '404 NotFound')
+          assert_equal false, subject.indices.exists?(:index => 'none')
+        end
+
+        should "re-raise generic exceptions" do
+          subject.expects(:perform_request).raises(StandardError)
+          assert_raise(StandardError) do
+            assert_equal false, subject.indices.exists?(:index => 'none')
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-api/test/unit/indices/exists_alias?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists_alias?_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class IndicesExistsAliasTest < ::Test::Unit::TestCase
+
+      context "Indices: Exists alias" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'HEAD', method
+            assert_equal '_alias/foo', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_alias? :name => 'foo'
+        end
+
+        should "perform request against multiple indices" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo,bar/_alias/bam', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_alias? :index => ['foo','bar'], :name => 'bam'
+        end
+
+        should "URL-escape the parts" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo%5Ebar/_alias/bar%2Fbam', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_alias? :index => 'foo^bar', :name => 'bar/bam'
+        end
+
+        should "return true for successful response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 200, 'OK')
+          assert_equal true, subject.indices.exists_alias?(:name => 'foo')
+        end
+
+        should "return false for 404 response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 404, 'Not Found')
+          assert_equal false, subject.indices.exists_alias?(:name => 'none')
+        end
+
+        should "return false on 'not found' exceptions" do
+          subject.expects(:perform_request).raises(StandardError.new '404 NotFound')
+          assert_nothing_raised do
+            assert_equal false, subject.indices.exists_alias?(:name => 'none')
+          end
+        end
+
+        should "re-raise generic exceptions" do
+          subject.expects(:perform_request).raises(StandardError)
+          assert_raise(StandardError) do
+            assert_equal false, subject.indices.exists_alias?(:name => 'none')
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/elasticsearch-api/test/unit/indices/exists_alias?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists_alias?_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Elasticsearch
   module Test
-    class IndicesExistsAliasTest < ::Test::Unit::TestCase
+    class IndicesExistsAliasQuestionTest < ::Test::Unit::TestCase
 
       context "Indices: Exists alias" do
         subject { FakeClient.new }

--- a/elasticsearch-api/test/unit/indices/exists_type?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists_type?_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Elasticsearch
   module Test
-    class IndicesExistsTypeTest < ::Test::Unit::TestCase
+    class IndicesExistsQuestionTypeTest < ::Test::Unit::TestCase
 
       context "Indices: Exists type" do
         subject { FakeClient.new }

--- a/elasticsearch-api/test/unit/indices/exists_type?_test.rb
+++ b/elasticsearch-api/test/unit/indices/exists_type?_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+module Elasticsearch
+  module Test
+    class IndicesExistsTypeTest < ::Test::Unit::TestCase
+
+      context "Indices: Exists type" do
+        subject { FakeClient.new }
+
+        should "perform correct request" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'HEAD', method
+            assert_equal 'foo/bar', url
+            assert_equal Hash.new, params
+            assert_nil   body
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_type? :index => 'foo', :type => 'bar'
+        end
+
+        should "perform request against multiple indices" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo,bar/bam', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_type? :index => ['foo','bar'], :type => 'bam'
+        end
+
+        should "URL-escape the parts" do
+          subject.expects(:perform_request).with do |method, url, params, body|
+            assert_equal 'foo%5Ebar/bar%2Fbam', url
+            true
+          end.returns(FakeResponse.new)
+
+          subject.indices.exists_type? :index => 'foo^bar', :type => 'bar/bam'
+        end
+
+        should "return true for successful response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 200, 'OK')
+          assert_equal true, subject.indices.exists_type?(:index => 'foo', :type => 'bar')
+        end
+
+        should "return false for 404 response" do
+          subject.expects(:perform_request).returns(FakeResponse.new 404, 'Not Found')
+          assert_equal false, subject.indices.exists_type?(:index => 'foo', :type => 'none')
+        end
+
+        should "return false on 'not found' exceptions" do
+          subject.expects(:perform_request).raises(StandardError.new '404 NotFound')
+          assert_nothing_raised do
+            assert_equal false, subject.indices.exists_type?(:index => 'foo', :type => 'none')
+          end
+        end
+
+        should "re-raise generic exceptions" do
+          subject.expects(:perform_request).raises(StandardError)
+          assert_raise(StandardError) do
+            assert_equal false, subject.indices.exists_type?(:index => 'foo', :type => 'none')
+          end
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Alias all predicate methods per elasticsearch/elasticsearch-ruby#133

Follow Ruby standards when returning a boolean value. This means the names of predicate methods (methods that return a boolean value) should end in a question mark. (i.e. Array#empty?).

Per: 
https://github.com/styleguide/ruby
http://pragmati.st/2012/03/24/the-elements-of-ruby-style-predicate-methods/
http://raganwald.com/2013/09/12/the-predicate-module-pattern.html

Done using [`alias_method`](http://ruby-doc.org//core-1.8.7/Module.html#method-i-alias_method)