### PR TITLE
Add predicate method aliases to examples

### DIFF
--- a/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/exists.rb
@@ -6,7 +6,7 @@ module Elasticsearch
       #
       # @example
       #
-      #     client.exists index: 'myindex', type: 'mytype', id: '1'
+      #     client.exists? index: 'myindex', type: 'mytype', id: '1'
       #
       # @option arguments [String] :id The document ID (*Required*)
       # @option arguments [String] :index The name of the index (*Required*)

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists.rb
@@ -7,7 +7,7 @@ module Elasticsearch
         #
         # @example Check whether index named _myindex_ exists
         #
-        #     client.indices.exists index: 'myindex'
+        #     client.indices.exists? index: 'myindex'
         #
         # @option arguments [List] :index A comma-separated list of indices to check (*Required*)
         # @option arguments [Boolean] :allow_no_indices Whether to ignore if a wildcard indices expression resolves into

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_alias.rb
@@ -7,7 +7,7 @@ module Elasticsearch
         #
         # @example Check whether index alias named _myalias_ exists
         #
-        #     client.indices.exists_alias name: 'myalias'
+        #     client.indices.exists_alias? name: 'myalias'
         #
         # @option arguments [List] :index A comma-separated list of index names to filter aliases
         # @option arguments [List] :name A comma-separated list of alias names to return

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_template.rb
@@ -3,7 +3,9 @@ module Elasticsearch
     module Indices
       module Actions
 
-        # TODO: Description
+        # Return true if the specified index template exists, false otherwise.
+        #
+        #     client.indices.exists_template? name: 'mytemplate'
         #
         # @option arguments [String] :name The name of the template (*Required*)
         # @option arguments [Boolean] :local Return local information, do not retrieve the state from master node (default: false)
@@ -29,6 +31,8 @@ module Elasticsearch
             raise e
           end
         end
+
+        alias_method :exists_template?, :exists_template
       end
     end
   end

--- a/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
+++ b/elasticsearch-api/lib/elasticsearch/api/actions/indices/exists_type.rb
@@ -5,6 +5,8 @@ module Elasticsearch
 
         # Return true if the specified type exists, false otherwise.
         #
+        #     client.indices.exists_type? type: 'mytype'
+        #
         # @option arguments [List] :index A comma-separated list of index names; use `_all`
         #                                 to check the types across all indices (*Required*)
         # @option arguments [List] :type A comma-separated list of document types to check (*Required*)


### PR DESCRIPTION
I missed adding examples to the RDoc's so that others are aware of the new method aliases. Sorry! :smiley:

This also addresses the `TODO: Description.` in `#exists_template(arguments = {}) ⇒ Object`